### PR TITLE
changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,7 @@
+# v0.7.3
+## Fixed
+- Fixed a bug where the previous binary would segfault when trying to run `pbstarphase build`
+- Pre-compiled static binary build system has changed to be Docker-based
+
 # v0.7.2
 Initial release.


### PR DESCRIPTION
## Fixed
- Fixed a bug where the previous binary would segfault when trying to run `pbstarphase build`
- Pre-compiled static binary build system has changed to be Docker-based