### PR TITLE
adding documentation for HLA changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v0.8.0
+## Changes
+- Added the ability to store HLA haplotype sequences from IMGTHLA in our database
+- Added the ability to read and write from a gzip-compressed (.gz) database file
+- Released an updated database with HLA haplotype sequences
+- Added the ability to call _HLA-A_ and _HLA-B_ using an HLA-aware database file and an aligned BAM file
+- Added several CLI parameters to support HLA calling
+
 # v0.7.3
 ## Fixed
 - Fixed a bug where the previous binary would segfault when trying to run `pbstarphase build`

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 The pb-StarPhase tool will diplotype pharmacogenomic (PGx) genes from [PacBio](https://www.pacb.com/technology/) datasets.
 Key features include:
 
-* Ability to create a database from latest CPIC information
-* Ability to diplotype most genes from CPIC
+* Ability to create a database from latest CPIC and IMGTHLA information
+* Ability to diplotype most genes from CPIC and as well as _HLA-A_ and _HLA-B_
 * Works on PacBio datasets from targeted and whole genome sequencing
 
 Authors: [Matt Holt](https://github.com/holtjma), [John Harting](https://github.com/jrharting), [Zev Kronenberg](https://github.com/zeeev)

--- a/data/README.md
+++ b/data/README.md
@@ -2,7 +2,7 @@
 ## Database files
 Databases were pre-generated for ease-of-use, sharing, and backwards compatibility when using older versions of pb-StarPhase.
 Though we will do our best to avoid breaking changes, database files are **not** guaranteed to work on versions that do not match.
-Additionally, these databases represent a snapshot in time of upstream data sources (e.g., CPIC).
+Additionally, these databases represent a snapshot in time of upstream data sources (e.g., CPIC and IMGTHLA).
 Running the same command at a later date may produce a different database with updated annotations.
 
 Each file is labeled as `{version}/cpic_{YYYYMMDD}.json` and represents a run of the following command using the specified `{version}` of pb-StarPhase on the corresponding date (`{YYYYMMDD}`):
@@ -11,3 +11,20 @@ Each file is labeled as `{version}/cpic_{YYYYMMDD}.json` and represents a run of
 pbstarphase build \
     --output-db {version}/cpic_{YYYYMMDD}.json
 ```
+
+# Data sources and citations
+## CPIC data citations
+All CPIC variants are sourced via the [CPIC API](https://cpicpgx.org/api-and-database/).
+As of this writing, versioning is *not* available via the API, so we instead tag the creation date in the `database_metadata/cpic_version` for all database files.
+CPIC data is released under [CC0 1.0 Universal (CC0 1.0) Public Domain Dedication](https://creativecommons.org/publicdomain/zero/1.0/) license.
+If you use the CPIC data within our database files, the authors and maintainers of CPIC ask that you follow their instructions for citing the relevant publications and resources: [https://cpicpgx.org/license/](https://cpicpgx.org/license/).
+
+## HLA data citations
+All HLA sequences are sourced and unmodified from [https://github.com/ANHIG/IMGTHLA](https://github.com/ANHIG/IMGTHLA).
+The exact git tag version is stored in the `database_metadata/hla_version` for all database versions after v0.8.0.
+If you use the HLA sequences within our database files, the authors and maintainers of IMGTHLA ask that you cite the following:
+
+1. Robinson J, Barker DJ, Georgiou X, Cooper MA, Flicek P, Marsh SGE: IPD-IMGT/HLA Database. Nucleic Acids Research (2020), 48:D948-55
+2. Robinson J, Malik A, Parham P, Bodmer JG, Marsh SGE: IMGT/HLA - a sequence database for the human major histocompatibility complex Tissue Antigens (2000), 55:280-287
+
+For more details, see the [IMGTHLA license file](https://github.com/ANHIG/IMGTHLA/blob/Latest/LICENCE.md).

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,5 +1,5 @@
 # Installing pb-StarPhase
-<!-- ## From conda
+## From conda
 The easiest way to install pb-StarPhase is through [conda](https://docs.conda.io/projects/conda/en/stable/user-guide/install/index.html):
 
 ```bash
@@ -8,8 +8,8 @@ conda create -n pbstarphase -c bioconda pbstarphase
 # OR install latest into current conda environment
 conda install pbstarphase
 # OR install a specific version into current conda environment
-conda install pbstarphase=0.7.0
-``` -->
+conda install pbstarphase=0.8.0
+```
 
 ## From GitHub
 Use the following instructions to get the most recent version of pb-StarPhase directly from GitHub:

--- a/docs/methods.md
+++ b/docs/methods.md
@@ -1,4 +1,5 @@
 # Methods
+## CPIC genes
 pb-StarPhase uses a relatively simple process to convert a VCF file into star-allele calls.
 The high-level process is outlined below:
 
@@ -6,3 +7,16 @@ The high-level process is outlined below:
 2. **Search the VCF file for normalized variants** - Given a set of normalized variant coordinates, this step will search the corresponding VCF region for variant calls that match those from the database. This step also normalizes the genotypes and tracks any relevant phasing information, if available.
 3. **Call diplotypes** - This step assigns all homozygous variants to both haplotypes. Heterozygous variants are then assigned combinatorially, and the resulting haplotype pairs are compared to the database. If both haplotypes match a known haplotype from the database, then the diplotype is recorded as a solution. Importantly, this method is phase-aware such that variants on the same phase set ID maintain the correct pairings. Additionally, variants on different phase set IDs are treated as effectively unphased relative to each other.
 4. **Report findings** - Each diplotype solution as well as relevant variant information is saved into the output JSON.
+
+## _HLA-A_ and _HLA-B_
+The diplotyping of HLA genes is more complicated due to frequent mismappings of other HLA sequences to the wrong positions in the genome.
+This can have the downstream effect of generating spurious or incorrect variant calling and/or phasing in the VCF file.
+As a result, pb-StarPhase uses a different, alignment-based approach to diplotype the HLA genes:
+
+1. **Load the HLA database** - This step loads the JSON database that was created from querying the IMGTHLA GitHub repo. Each haplotype sequence is loaded into memory for the following steps. 
+2. **Load fully spanning reads** - This step will parse the alignment file (BAM) and extract all reads that **fully span** the gene region of interest. We note that the haplotypes stored in IMGTHLA do not have the same mapping coordinates, so we have defined the regions of interest as follows (subject to change as we iterate on performance):
+    * _HLA-A_ - chr6:29942254-29945870
+    * _HLA-B_ - chr6:31353362-31357442
+3. **Score each HLA haplotype against each read** - This step will align each cDNA and DNA sequence against each read and save the edit distance of the mapping against that read. By default, any HLA haplotypes that are missing a DNA sequence are ignored. Any read with an edit distance that is too high will be ignored (this removes mismapped reads).
+4. **Call best diplotype** - This step performs a ranked-choice vote where each read mapping is allowed one vote. The process iteratively excludes candidate haplotypes based on the number of votes as well as the edit distance for tie-breaking. If all candidates have a "high" vote fraction (default: >=10%), then a more complicated full comparison is used to exclude a candidate. Once only two candidates remain, the algorithm compares the votes to determine whether it should be reported as heterozygous for both candidates or homozygous for the dominant candidate.
+5. **Report findings** - In contrast to the CPIC genes, only a single diplotype result is ever reported for the HLA genes. Additionally, relevant mapping information is saved into the output JSON.


### PR DESCRIPTION
# v0.8.0
## Changes
- Added the ability to store HLA haplotype sequences from IMGTHLA in our database
- Added the ability to read and write from a gzip-compressed (.gz) database file
- Released an updated database with HLA haplotype sequences
- Added the ability to call _HLA-A_ and _HLA-B_ using an HLA-aware database file and an aligned BAM file
- Added several CLI parameters to support HLA calling
