### PR TITLE
bug fix for homozygous *5 in targeted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.0.1
+## Fixed
+- Fixed an issue where a homozygous deletion in CYP2D6 (\*5/\*5) was not considered a valid diplotype when using `--normalize-d6-only`
+
 # v1.0.0
 ## Changes
 - Source code is included in the GitHub repository

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1384,7 +1384,7 @@ checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pbstarphase"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "assert_approx_eq",
  "bio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pbstarphase"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/LICENSE-THIRDPARTY.json
+++ b/LICENSE-THIRDPARTY.json
@@ -1333,7 +1333,7 @@
   },
   {
     "name": "pbstarphase",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "authors": null,
     "repository": null,
     "license": null,


### PR DESCRIPTION
# v1.0.1
## Fixed
- Fixed an issue where a homozygous deletion in CYP2D6 (\*5/\*5) was not considered a valid diplotype when using `--normalize-d6-only`
