### PR TITLE
Structural variant support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.3.0
+## Changes
+- Adds support for externally called structural variants and corresponding PGx haplotypes
+  - A new option `--sv-vcf` can be used to provide a structural variant VCF file from pbsv or sawfish
+  - Updated the database build to include _CYP2C19_ known whole-gene (\*36) and partial-gene deletions (\*37) based on PharmVar definitions
+
 # v1.2.0
 ## Changes
 - Added a new debug output file: `cyp2d6_alleles.json`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1344,7 +1344,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pbstarphase"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "assert_approx_eq",
  "bio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pbstarphase"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/LICENSE-THIRDPARTY.json
+++ b/LICENSE-THIRDPARTY.json
@@ -1306,7 +1306,7 @@
   },
   {
     "name": "pbstarphase",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "authors": null,
     "repository": null,
     "license": null,

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -80,6 +80,24 @@ pbstarphase diplotype \
     ...
 ```
 
+## Structural variant diplotyping
+Starting with v1.3.0, pb-StarPhase includes support structural variants provided from an external program.
+To enable structural variants (SVs), an additional VCF file must be provided using the `--sv-vcf` parameter:
+
+```bash
+pbstarphase diplotype \
+    --vcf ${VCF} \
+    --sv-vcf ${SV_VCF} \
+    ...
+```
+
+We recommend generating SV calls using [sawfish](https://github.com/PacificBiosciences/sawfish), and then joint phasing them with the small variants using [HiPhase](https://github.com/PacificBiosciences/HiPhase).
+This will generate structural variants with complementary phase information to the small variants.
+While phasing is not required for StarPhase, it significantly reduces the ambiguity of output diplotypes.
+
+The database for v1.3.0 includes deletion SVs for _CYP2C19_, and we note that SVs in additional genes may get support in future releases.
+If you have an SV you would like covered, please let us know with a GitHub issue.
+
 # Supported upstream processes
 The following upstream processes are supported as inputs to pb-StarPhase:
 
@@ -123,6 +141,11 @@ Fields are described below, with a partial example further down:
       * `position` - The **0-based** position along the chromosome.
       * `reference` - The reference sequence at this position.
       * `alternate` - The alternate (variant) sequence at this position.
+      * `sv_stats` - Optional field that only applies to structural variants
+        * `sv_type` - The corresponding type of structural variant
+        * `start` - Start coordinate of the structural variant
+        * `end` - End coordinate of the structural variant
+        * `haplotype_label` - A label that is assigned to the structural variant based on the database definitions
     * `normalized_genotype` - Describes the associated genotype after genotype normalization.
       * `genotype` - This will almost always match the genotype (GT) from the VCF file; multi-allelic sites will get converted into one of the following: `[0/0, 0/1, 0|1, 1|0, 1/1]`.
       * `phase_set` - A phase set ID (PS) from the VCF file; this will be `null` for unphased or homozygous variants. Note that variants on different phase sets are _not_ considered phased with each other (they are effectively, unphased).

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -81,7 +81,7 @@ pbstarphase diplotype \
 ```
 
 ## Structural variant diplotyping
-Starting with v1.3.0, pb-StarPhase includes support structural variants provided from an external program.
+Starting with v1.3.0, pb-StarPhase includes support for structural variants provided from an external program.
 To enable structural variants (SVs), an additional VCF file must be provided using the `--sv-vcf` parameter:
 
 ```bash
@@ -91,7 +91,7 @@ pbstarphase diplotype \
     ...
 ```
 
-We recommend generating SV calls using [sawfish](https://github.com/PacificBiosciences/sawfish), and then joint phasing them with the small variants using [HiPhase](https://github.com/PacificBiosciences/HiPhase).
+We recommend generating SV calls using [sawfish](https://github.com/PacificBiosciences/sawfish), and then jointly phasing them with small variants using [HiPhase](https://github.com/PacificBiosciences/HiPhase).
 This will generate structural variants with complementary phase information to the small variants.
 While phasing is not required for StarPhase, it significantly reduces the ambiguity of output diplotypes.
 

--- a/src/build_database.rs
+++ b/src/build_database.rs
@@ -59,7 +59,6 @@ pub fn pull_database_cpic_api(reference_genome: &ReferenceGenome) -> Result<PgxD
     let hla_data: BTreeMap<String, HlaAlleleDefinition> = get_hla_sequences(&latest_hla_version)?;
 
     // finally, get the PharmVar CYP2D6 data
-    // let (pharmvar_version, cyp2d6_data) = get_pharmvar_sequences("CYP2D6", "current")?;
     let (pharmvar_version, cyp2d6_data) = get_pharmvar_variants("CYP2D6", "current")?;
     info!("Found latest PharmVar version: {pharmvar_version}");
 

--- a/src/cli/diplotype.rs
+++ b/src/cli/diplotype.rs
@@ -34,6 +34,13 @@ pub struct DiplotypeSettings {
     #[clap(help_heading = Some("Input/Output"))]
     pub vcf_filename: Option<PathBuf>,
 
+    /// Input structural variant file in VCF format
+    #[clap(short = 's')]
+    #[clap(long = "sv-vcf")]
+    #[clap(value_name = "VCF")]
+    #[clap(help_heading = Some("Input/Output"))]
+    pub sv_vcf_filename: Option<PathBuf>,
+
     /// Input alignment file in BAM format, can be specified multiple times; required for HLA diplotyping
     #[clap(short = 'b')]
     #[clap(long = "bam")]
@@ -184,6 +191,7 @@ pub fn check_diplotype_settings(mut settings: DiplotypeSettings) -> Result<Diplo
     check_required_filename(&settings.input_database, "Database JSON");
     check_required_filename(&settings.reference_filename, "Reference FASTA");
     check_optional_filename(settings.vcf_filename.as_deref(), "VCF file");
+    check_optional_filename(settings.sv_vcf_filename.as_deref(), "SV VCF file");
 
     // these are optional, but make sure that any specified exist
     for bam_fn in settings.bam_filenames.iter() {
@@ -195,6 +203,11 @@ pub fn check_diplotype_settings(mut settings: DiplotypeSettings) -> Result<Diplo
     info!("\tReference: {:?}", &settings.reference_filename);
     if let Some(vcf_fn) = settings.vcf_filename.as_ref() {
         info!("\tVCF: {:?}", vcf_fn);
+        if let Some(sv_fn) = settings.sv_vcf_filename.as_ref() {
+            info!("\tSV VCF: {:?}", sv_fn);
+        } else {
+            info!("\tSV VCF: None");
+        }
     } else {
         warn!("\tVCF: No variant call files provided, all variant-based diplotyping is disabled")
     }

--- a/src/data_types/mod.rs
+++ b/src/data_types/mod.rs
@@ -15,3 +15,5 @@ pub mod mapping;
 pub mod normalized_variant;
 /// Contains definitions related to the representation of a final diplotype
 pub mod pgx_diplotypes;
+/// Contains functionality for support CPIC structural variants
+pub mod pgx_structural_variants;

--- a/src/data_types/pgx_diplotypes.rs
+++ b/src/data_types/pgx_diplotypes.rs
@@ -151,7 +151,7 @@ impl PgxGeneDetails {
 }
 
 /// Contains all the information related to a single gene's diplotype result
-#[derive(Clone, Debug, PartialEq, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct Diplotype {
     /// short string for haplotype 1
     hap1: String,
@@ -198,6 +198,14 @@ impl Diplotype {
             self.hap2.clone()
         };
         format!("{h1}/{h2}")
+    }
+}
+
+impl PartialEq for Diplotype {
+    fn eq(&self, other: &Self) -> bool {
+        // this allows for a swap in hap1/hap2 and we still report identity
+        (self.hap1 == other.hap1 && self.hap2 == other.hap2) ||
+            (self.hap1 == other.hap2 && self.hap2 == other.hap1)
     }
 }
 

--- a/src/data_types/pgx_structural_variants.rs
+++ b/src/data_types/pgx_structural_variants.rs
@@ -1,0 +1,142 @@
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::collections::btree_map::Entry;
+
+use serde::{Deserialize, Serialize};
+use simple_error::{SimpleError, bail};
+
+/// Structure containing all known PGx SVs for a particular gene
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct PgxStructuralVariants {
+    /// Map from a full gene deletion ID to the definition; at most one "generic" full deletion in the set
+    full_gene_deletions: BTreeMap<String, FullDeletion>,
+    /// Map from a full gene deletion ID to the definition; at most one "generic" partial deletion in the set
+    partial_gene_deletions: BTreeMap<String, PartialDeletion>
+}
+
+impl PgxStructuralVariants {
+    /// Adds a full deletion event to the alleles for this gene
+    /// * `label` - the label (i.e. genotype) for this event
+    /// * `event` - the full deletion to add
+    /// # Errors
+    /// * if a duplicate label is provided
+    pub fn add_full_deletion(&mut self, label: String, event: FullDeletion) -> Result<(), SimpleError> {
+        // make sure this definition is not in the partial deletions
+        if self.partial_gene_deletions.contains_key(&label) {
+            bail!("Full deletion label is already in partial gene deletion definitions: {label}");
+        }
+
+        // now check the full deletions
+        match self.full_gene_deletions.entry(label) {
+            Entry::Vacant(vacant_entry) => {
+                vacant_entry.insert(event);
+            },
+            Entry::Occupied(occupied_entry) => {
+                bail!("Duplicate full deletion detected: {}", occupied_entry.key());
+            },
+        };
+        Ok(())
+    }
+
+    /// Adds a partial deletion event to the alleles for this gene
+    /// * `label` - the label (i.e. genotype) for this event
+    /// * `event` - the full deletion to add
+    /// # Errors
+    /// * if a duplicate label is provided
+    pub fn add_partial_deletion(&mut self, label: String, event: PartialDeletion) -> Result<(), SimpleError> {
+        // make sure this definition is not in the full deletions
+        if self.full_gene_deletions.contains_key(&label) {
+            bail!("Partial deletion label is already in full gene deletion definitions: {label}");
+        }
+
+        // now check the full deletions
+        match self.partial_gene_deletions.entry(label) {
+            Entry::Vacant(vacant_entry) => {
+                vacant_entry.insert(event);
+            },
+            Entry::Occupied(occupied_entry) => {
+                bail!("Duplicate partial deletion detected: {}", occupied_entry.key());
+            },
+        };
+        Ok(())
+    }
+
+    /// This will return a list of all genes that are potentially impacted by the defined structural variants
+    pub fn impacted_gene_set(&self) -> BTreeSet<String> {
+        let mut ret: BTreeSet<String> = Default::default();
+        for fd in self.full_gene_deletions.values() {
+            ret.extend(fd.full_genes_deleted().iter().cloned());
+        }
+
+        for pd in self.partial_gene_deletions.values() {
+            ret.extend(pd.exons_deleted().keys().cloned());
+        }
+
+        ret
+    }
+
+    // getters
+    pub fn full_gene_deletions(&self) -> &BTreeMap<String, FullDeletion> {
+        &self.full_gene_deletions
+    }
+
+    pub fn partial_gene_deletions(&self) -> &BTreeMap<String, PartialDeletion> {
+        &self.partial_gene_deletions
+    }
+}
+
+/// Describes a full deletion structural variant
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct FullDeletion {
+    /// If True, this is a generic full deletion, which is generally a core allele in PGx land
+    is_generic: bool,
+    /// The set of genes that must be deleted to match; if `is_generic`, then this should just be the primary gene
+    full_genes_deleted: BTreeSet<String>
+}
+
+impl FullDeletion {
+    /// Constructor
+    pub fn new(is_generic: bool, full_genes_deleted: BTreeSet<String>) -> Self {
+        Self {
+            is_generic,
+            full_genes_deleted
+        }
+    }
+
+    // getters
+    pub fn is_generic(&self) -> bool {
+        self.is_generic
+    }
+
+    pub fn full_genes_deleted(&self) -> &BTreeSet<String> {
+        &self.full_genes_deleted
+    }
+}
+
+/// Describes a partial deletion structural variant
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct PartialDeletion {
+    /// If True, this is a generic partial deletion, which is generally a core allele in PGx land
+    is_generic: bool,
+    /// A list of genes and the exons that are deleted; this exon list is always relative to the reference orientation
+    exons_deleted: BTreeMap<String, std::ops::Range<usize>>
+}
+
+impl PartialDeletion {
+    /// Constructor
+    pub fn new(is_generic: bool, exons_deleted: BTreeMap<String, std::ops::Range<usize>>) -> Self {
+        Self {
+            is_generic,
+            exons_deleted
+        }
+    }
+
+    // getters
+    pub fn is_generic(&self) -> bool {
+        self.is_generic
+    }
+
+    pub fn exons_deleted(&self) -> &BTreeMap<String, std::ops::Range<usize>> {
+        &self.exons_deleted
+    }
+}

--- a/src/diplotyper.rs
+++ b/src/diplotyper.rs
@@ -1,19 +1,23 @@
 
+use itertools::Itertools;
 use log::{debug, error, info, trace, warn};
 use rust_htslib::bcf;
 use rust_htslib::bcf::Read;
 use rust_htslib::bcf::record::GenotypeAllele;
 use rust_lib_reference_genome::reference_genome::ReferenceGenome;
-use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
-use simple_error::bail;
-use std::collections::hash_map::Entry::{Occupied, Vacant};
+use rustc_hash::FxHashSet as HashSet;
+use simple_error::{bail, SimpleError};
+use std::collections::btree_map::Entry::{Occupied, Vacant};
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
 use crate::cli::diplotype::DiplotypeSettings;
 use crate::cyp2d6::caller::diplotype_cyp2d6;
 use crate::data_types::database::{PgxDatabase, PgxGene, PgxVariant};
-use crate::data_types::normalized_variant::{Genotype, NormalizedGenotype, NormalizedVariant, NormalizedPgxHaplotype};
+use crate::data_types::gene_definition::GeneCollection;
+use crate::data_types::normalized_variant::{Genotype, NormalizedGenotype, NormalizedVariant, NormalizedPgxHaplotype, SvType};
 use crate::data_types::pgx_diplotypes::{PgxDiplotypes, PgxGeneDetails, PgxVariantDetails, Diplotype};
+use crate::data_types::pgx_structural_variants::PgxStructuralVariants;
 use crate::hla::caller::{diplotype_hla_batch, diplotype_hla};
 use crate::util::file_io::load_file_lines;
 use crate::visualization::debug_bam_writer::DebugBamWriter;
@@ -72,6 +76,9 @@ pub fn call_diplotypes(
             debug!("Loaded {} normalized variants.", variant_hash.len());
             debug!("Loaded {} normalized haplotypes.", normalized_haplotypes.len());
 
+            // load the SV haplotypes also, but keep them separate
+            let opt_structural_variants = gene_entry.structural_variants();
+
             // make sure we have variants, otherwise we can't do anything
             if variant_hash.is_empty() {
                 warn!("No variants found for {gene_name}, returning default reference allele.");
@@ -89,22 +96,45 @@ pub fn call_diplotypes(
             }
 
             // load the normalize variants from the VCF
-            let vcf_variants: HashMap<NormalizedVariant, NormalizedGenotype> = load_vcf_variants(vcf_fn, &variant_hash, reference_genome)?;
+            let mut vcf_variants: BTreeMap<NormalizedVariant, NormalizedGenotype> = load_vcf_variants(vcf_fn, &variant_hash, reference_genome)?;
             debug!("Loaded {} normalized genotypes.", vcf_variants.len());
+
+            // if we have an SV VCF, load variants for it also
+            let sv_vcf_variants: BTreeMap<NormalizedVariant, NormalizedGenotype> = if let Some(sv_vcf) = cli_settings.sv_vcf_filename.as_deref() {
+                load_sv_vcf_variants(sv_vcf, opt_structural_variants, database.gene_collection())?
+            } else {
+                Default::default()
+            };
+            debug!("Loaded {} SV genotypes.", sv_vcf_variants.len());
+
+            // add the structural variants to the full list
+            vcf_variants.extend(sv_vcf_variants.into_iter());
             
             // finally, call the diplotype from the loaded variants
             let diplotype = solve_diplotype(&normalized_haplotypes, &vcf_variants)?;
             debug!("Diplotype for {gene_name} => {:?}", diplotype.iter().map(|d| d.diplotype()).collect::<Vec<&str>>());
+
+            // save the variant details for output
             let variant_details: Vec<PgxVariantDetails> = vcf_variants.into_iter()
                 .map(|(nv, ng)| {
-                    let variant_meta = variant_hash.get(&nv).unwrap();
-                    PgxVariantDetails::new(
-                        variant_meta.variant_id,
-                        variant_meta.name.clone(),
-                        variant_meta.dbsnp_id.clone(),
-                        nv,
-                        ng
-                    )
+                    if nv.is_sv() {
+                        PgxVariantDetails::new(
+                            u64::MAX,
+                            "structural_variant".to_string(),
+                            None,
+                            nv,
+                            ng
+                        )
+                    } else {
+                        let variant_meta = variant_hash.get(&nv).unwrap();
+                        PgxVariantDetails::new(
+                            variant_meta.variant_id,
+                            variant_meta.name.clone(),
+                            variant_meta.dbsnp_id.clone(),
+                            nv,
+                            ng
+                        )
+                    }
                 })
                 .collect();
             let gene_details = PgxGeneDetails::new(
@@ -283,7 +313,7 @@ struct VariantMeta {
 /// Note that if a variant fails to normalize, the whole haplotype will be ignored.
 /// 
 /// Returns a tuple (`variant_hash`, `normalized_haplotypes`):
-/// * `variant_hash` - a HashMap from a NormalizedVariant to the original variant metadata
+/// * `variant_hash` - a map from a NormalizedVariant to the original variant metadata
 /// * `normalized_haplotypes` - a Vec of NormalizedPgxHaplotypes loaded from the database
 /// # Arguments
 /// * `gene_entry` - the single gene entry from our database
@@ -294,9 +324,9 @@ struct VariantMeta {
 /// * if a variant in the database is incomplete
 #[allow(clippy::type_complexity)]
 fn load_database_haplotypes(gene_entry: &PgxGene, reference_genome: Option<&ReferenceGenome>) 
-    -> Result<(HashMap<NormalizedVariant, VariantMeta>, Vec<NormalizedPgxHaplotype>), Box<dyn std::error::Error>> {
+    -> Result<(BTreeMap<NormalizedVariant, VariantMeta>, Vec<NormalizedPgxHaplotype>), Box<dyn std::error::Error>> {
     let mut normalized_haplotypes: Vec<NormalizedPgxHaplotype> = vec![];
-    let mut normalized_variants: HashMap<NormalizedVariant, VariantMeta> = Default::default();
+    let mut normalized_variants: BTreeMap<NormalizedVariant, VariantMeta> = Default::default();
 
     let pgx_variants = gene_entry.variants();
     for (haplotype_name, pgx_haplotype) in gene_entry.defined_haplotypes() {
@@ -401,14 +431,14 @@ fn load_database_haplotypes(gene_entry: &PgxGene, reference_genome: Option<&Refe
 /// * if the chromosome for the variants cannot be found in the VCF
 /// # Panics
 /// * if the variant_hash is empty, the chrom.unwrap() will panic
-fn load_vcf_variants(vcf_fn: &Path, variant_hash: &HashMap<NormalizedVariant, VariantMeta>, reference_genome: Option<&ReferenceGenome>) 
-    -> Result<HashMap<NormalizedVariant, NormalizedGenotype>, Box<dyn std::error::Error>> {
+fn load_vcf_variants(vcf_fn: &Path, variant_hash: &BTreeMap<NormalizedVariant, VariantMeta>, reference_genome: Option<&ReferenceGenome>) 
+    -> Result<BTreeMap<NormalizedVariant, NormalizedGenotype>, Box<dyn std::error::Error>> {
     // first we need to open up the vcf and pull out the header
     let mut vcf_reader: bcf::IndexedReader = bcf::IndexedReader::from_path(vcf_fn)?;
     let vcf_header: bcf::header::HeaderView = vcf_reader.header().clone();
 
     // prep our return struct
-    let mut ret: HashMap<NormalizedVariant, NormalizedGenotype> = Default::default();
+    let mut ret: BTreeMap<NormalizedVariant, NormalizedGenotype> = Default::default();
 
     // iterate over each variant, search for the corresponding entry in the VCF
     for (variant, _v_meta) in variant_hash.iter() {
@@ -569,7 +599,7 @@ fn load_vcf_variants(vcf_fn: &Path, variant_hash: &HashMap<NormalizedVariant, Va
 
         // check if the search found anything
         if let Some(ng) = search_genotype {
-            debug!("Genotype found for {variant:?}: {ng:?}");
+            debug!("\tGenotype found for {variant:?}: {ng:?}");
             ret.insert(variant.clone(), ng);
         } else {
             trace!("Genotype not found.");
@@ -577,6 +607,425 @@ fn load_vcf_variants(vcf_fn: &Path, variant_hash: &HashMap<NormalizedVariant, Va
     }
 
     Ok(ret)
+}
+
+/// This will load the relevant structural variants from an SV VCF.
+/// If one is found, the haplotype is return with a NormalizedGenotype.
+/// # Arguments
+/// * `vcf_fn` - The VCF file to look through
+/// * `opt_structural_variants` - Optional structure variants to look for; if None (most PGx genes), this function returns empty results
+fn load_sv_vcf_variants(vcf_fn: &Path, opt_structural_variants: Option<&PgxStructuralVariants>, gene_collection: &GeneCollection) -> Result<BTreeMap<NormalizedVariant, NormalizedGenotype>, Box<dyn std::error::Error>> {
+    // if there are no SVs noted, then there is nothing to search for here
+    let structural_variants = match opt_structural_variants {
+        Some(sv) => sv,
+        None => {
+            // no reason to do any processing here
+            return Ok(Default::default());
+        }
+    };
+
+    // first, figure out the search coordinates in the VCF file
+    let sv_gene_set = structural_variants.impacted_gene_set();
+    let mut chrom = None;
+    let mut max_position = 0;
+    let mut min_position = u64::MAX;
+
+    for gene in sv_gene_set.iter() {
+        // get the gene definition
+        let gene_def = gene_collection.gene_dict().get(gene)
+            .ok_or(SimpleError::new(format!("Missing gene definition ({gene}) for structural variant")))?;
+        let coordinates = gene_def.coordinates();
+
+        // set the chromosome, or make sure it matches previous
+        match chrom {
+            Some(c) => {
+                if c != coordinates.chrom() {
+                    bail!("Structural variant gene set is not all on the same chromosome: {sv_gene_set:?}");
+                }
+            },
+            None => {
+                chrom = Some(coordinates.chrom());
+            }
+        };
+
+        // set the bounds
+        min_position = min_position.min(coordinates.start());
+        max_position = max_position.max(coordinates.end());
+    }
+
+    if chrom.is_none() {
+        // this shouldn't really happen, but lets handle it
+        return Ok(Default::default());
+    }
+
+    // we need to open up the vcf and pull out the header
+    let mut vcf_reader: bcf::IndexedReader = bcf::IndexedReader::from_path(vcf_fn)?;
+    let vcf_header: bcf::header::HeaderView = vcf_reader.header().clone();
+
+    // prep our return struct
+    let mut ret: BTreeMap<NormalizedVariant, NormalizedGenotype> = Default::default();
+
+    // iterate over each variant, search for the corresponding entry in the VCF
+    let chrom = chrom.unwrap();
+    let chrom_index: u32 = vcf_header.name2rid(chrom.as_bytes())?;
+
+    match vcf_reader.fetch(chrom_index, min_position, Some(max_position)) {
+        Ok(()) => {
+            for record_result in vcf_reader.records() {
+                let record: rust_htslib::bcf::Record = record_result?;
+                let alleles = record.allele_count();
+                if alleles != 2 {
+                    warn!("SV records with more than two alleles are not supported, ignoring");
+                    continue;
+                }
+
+                // our list of PGx variant only include deletions (for now), so filter on that
+                let sv_type = get_sv_type(&record)?;
+                if sv_type != SvType::Deletion {
+                    continue;
+                }
+
+                // pos return 0-based, end should 0-based exclusive
+                let start: u64 = record.pos().try_into()?;
+                let end: u64 = get_sv_end(&record)?.try_into()?;
+
+                // now check if this matches a defined deletion
+                let opt_sv_id = is_deletion(gene_collection, structural_variants, start, end)?;
+                if let Some(sv_id) = opt_sv_id {
+                    // regardless of full or partial, we found something and need to extract it's info
+                    let opt_genotype = get_sv_genotype(&record)?;
+                    if let Some(gt) = opt_genotype {
+                        if gt.genotype() == Genotype::HomozygousReference {
+                            // ignore these
+                            continue;
+                        }
+
+                        // we have a non-reference genotype and a variant of interest, lets put it into the list
+                        let normalized_variant = NormalizedVariant::new_sv(
+                            sv_type, chrom.to_string(), start as usize, end as usize, sv_id
+                        )?;
+
+                        debug!("\tGenotype found for {normalized_variant:?}: {gt:?}");
+                        if let Some(previous_entry) = ret.insert(normalized_variant.clone(), gt) {
+                            bail!("Detected duplicate entry for normalized SV: {normalized_variant:?} => {previous_entry:?}");
+                        }
+                    } else {
+                        // we couldn't parse the genotype for some reason
+                        warn!("Failed to parse genotype for SV record: {}", record.desc());
+                    }
+                }
+            }
+        },
+        Err(e) => {
+            warn!("Received \'{}\', while seeking to {}:{}-{}, assuming no variants present", e, chrom, min_position, max_position);
+        }
+    };
+
+    Ok(ret)
+}
+
+/// Wrapper utility to pull out a single INFO:SVTYPE field and handle errors.
+/// # Arguments
+/// * `record` - the record to parse
+/// # Errors
+/// * if the INFO:SVTYPE field does not exist
+/// * if the INFO:SVTYPE field has more than one value in it
+fn get_sv_type(record: &rust_htslib::bcf::Record) -> Result<SvType, Box<dyn std::error::Error>> {
+    let opt_svtype = match record.info(b"SVTYPE").string() {
+        Ok(f) => f,
+        Err(e) => bail!("Error while parsing INFO:SVTYPE tag: {} => {e}", record.desc()),
+    };
+    match opt_svtype {
+        Some(b) => {
+            if b.len() != 1 {
+                bail!("Detected INFO:SVTYPE with more than one value: {} => {b:?}", record.desc());
+            }
+
+            // finally, match on what is contained
+            let svtype = match b[0] {
+                b"DEL" => SvType::Deletion,
+                _ => SvType::Unknown
+            };
+            Ok(svtype)
+        }
+        None => {
+            bail!("No INFO:SVTYPE in record: {}", record.desc());
+        }
+    }
+}
+
+/// Wrapper utility to pull out a single INFO:END field and handle errors.
+/// # Arguments
+/// * `record` - the record to parse
+/// # Errors
+/// * if the INFO:END field does not exist
+/// * if the INFO:END field has more than one value in it
+fn get_sv_end(record: &rust_htslib::bcf::Record) -> Result<i32, Box<dyn std::error::Error>> {
+    let opt_end = match record.info(b"END").integer() {
+        Ok(f) => f,
+        Err(e) => bail!("Error while parsing INFO:END tag: {} => {e}", record.desc()),
+    };
+    match opt_end {
+        Some(b) => {
+            if b.len() != 1 {
+                bail!("Detected INFO:END with more than one value: {} => {b:?}", record.desc());
+            }
+
+            Ok(b[0])
+        },
+        None => {
+            bail!("No INFO:END in record: {}", record.desc());
+        }
+    }
+}
+
+/// Wrapper utility to pull out a record's genotype.
+/// This function assumes non-multi-allelic and will return None if a multi-allelic site is provided.
+/// # Arguments
+/// * `record` - the record to parse
+fn get_sv_genotype(record: &rust_htslib::bcf::Record) -> Result<Option<NormalizedGenotype>, Box<dyn std::error::Error>> {
+    // TODO: if we want to allow for multi-sample VCFs, we need to adjust this
+    let all_genotypes = record.genotypes()?;
+    let genotype = all_genotypes.get(0);
+    if genotype.len() != 2 {
+        warn!("Error while parsing SV record with genotype.len() != 2, ignoring: {} => {:?}", record.desc(), genotype);
+        return Ok(None);
+    }
+
+    // figure out what the genotype is
+    let mut is_phased = false;
+    let gt1 = match genotype[0] {
+        GenotypeAllele::Unphased(at) => Some(at),
+        GenotypeAllele::Phased(at) => {
+            is_phased = true;
+            Some(at)
+        },
+        //TODO: ignore these for now, not sure how to handle it?
+        GenotypeAllele::UnphasedMissing |
+        GenotypeAllele::PhasedMissing=> None
+    };
+    let gt2 = match genotype[1] {
+        GenotypeAllele::Unphased(at) => Some(at),
+        GenotypeAllele::Phased(at) => {
+            is_phased = true;
+            Some(at)
+        },
+        //TODO: ignore these for now, not sure how to handle it?
+        GenotypeAllele::UnphasedMissing |
+        GenotypeAllele::PhasedMissing=> None
+    };
+
+    // if we encounter empty genotypes, we will ignore them for now
+    if gt1.is_none() || gt2.is_none() {
+        warn!("Error while parsing SV record with incomplete genotype, ignoring: {} => {:?}", record.desc(), genotype);
+        return Ok(None);
+    }
+
+    // these should only be 0 or 1
+    let gt1 = gt1.unwrap() as usize;
+    let gt2 = gt2.unwrap() as usize;
+    assert!(gt1 < 2 && gt2 < 2);
+
+    // add the phase set if it's phased
+    let phase_set: Option<usize> = if is_phased {
+        // check for a phase set ID if we are phased
+        match record.format(b"PS").integer() {
+            Ok(all_ps_tag) => {
+                // phase set parsing was fine
+                let ps_tag = all_ps_tag[0];
+                assert_eq!(ps_tag.len(), 1);
+                Some(ps_tag[0] as usize)
+            },
+            Err(e) => {
+                // phase set parsing failed, which is weird
+                warn!("Failed to parse \"PS\" tag for variant, setting unphased: {} => {}", record.desc(), e);
+                is_phased = false;
+                None
+            }
+        }
+    } else {
+        // marked as unphased, so no ID
+        None
+    };
+
+    // lastly, build the final genotype
+    let genotype = if gt1 == gt2 {
+        if gt1 == 0 {
+            // this is homozygous reference, return nothing
+            Genotype::HomozygousReference
+        } else {
+            // homozygous alternate
+            Genotype::HomozygousAlternate
+        }
+    } else if is_phased {
+        if gt1 == 0 {
+            // heterozygous phased and the ALT is the second allele; i.e. 0|1
+            assert_eq!(gt2, 1);
+            Genotype::HeterozygousPhased
+        } else {
+            // heterozygous phased and the ALT is the first allele; i.e. 1|0
+            assert_eq!(gt2, 0);
+            Genotype::HeterozygousPhasedFlip
+        }
+    } else {
+        // this is unphased heterozygous
+        Genotype::HeterozygousUnphased
+    };
+
+    Ok(Some(NormalizedGenotype::new(
+        genotype, phase_set
+    )))
+}
+
+/// Wrapper function that will check for a full deletion and then a partial deletion.
+/// Returns an optional ID corresponding to the ID that was found.
+/// # Arguments
+/// * `gene_collection` - the set of known gene definitions
+/// * `structural_variants` - all defined structural variants to compare against
+/// * `start` - start coordinates of the SV, 0-based inclusive
+/// * `end` - end coordinates of the SV, 0-base exclusive
+fn is_deletion(gene_collection: &GeneCollection, structural_variants: &PgxStructuralVariants, start: u64, end: u64) -> Result<Option<String>, SimpleError> {
+    // first check for full gene deletions
+    match is_full_deletion(gene_collection, structural_variants, start, end)? {
+        Some(id) => Ok(Some(id)),
+        None => is_partial_deletion(gene_collection, structural_variants, start, end)
+    }
+}
+
+/// Will see if the given structural variant region matches a described full deletion
+/// # Arguments
+/// * `gene_collection` - the set of known gene definitions
+/// * `structural_variants` - all defined structural variants to compare against
+/// * `start` - start coordinates of the SV, 0-based inclusive
+/// * `end` - end coordinates of the SV, 0-base exclusive
+fn is_full_deletion(gene_collection: &GeneCollection, structural_variants: &PgxStructuralVariants, start: u64, end: u64) -> Result<Option<String>, SimpleError> {
+    // get the full set of deletable genes
+    let all_deletable_genes: BTreeSet<String> = structural_variants.full_gene_deletions().values()
+        .flat_map(|fd| fd.full_genes_deleted().iter())
+        .cloned()
+        .collect();
+
+    // make sure all the genes have a definition
+    for gene in all_deletable_genes.iter() {
+        if !gene_collection.gene_dict().contains_key(gene) {
+            bail!("Gene collection does not contain a definition for {gene}");
+        }
+    }
+
+    // now get the set of deleted genes
+    let deleted_genes: BTreeSet<String> = all_deletable_genes.iter()
+        .filter_map(|g| {
+            // unwrap was checked for above
+            let gene_def = gene_collection.gene_dict().get(g).unwrap();
+            let coordinates = gene_def.coordinates();
+            let gene_start = coordinates.start();
+            let gene_end = coordinates.end();
+            if gene_start >= start && gene_end <= end {
+                // gene is FULLY contained in the deleted region
+                Some(g.clone())
+            } else {
+                // gene is NOT FULLY contained, so we do not count it
+                None
+            }
+        })
+        .collect();
+
+    // now figure out if anything matches it
+    let mut opt_del_id: Option<String> = None;
+    for (allele, full_deletion) in structural_variants.full_gene_deletions().iter() {
+        let fd_gene = full_deletion.full_genes_deleted();
+        if full_deletion.is_generic() {
+            // this is a generic definition, check if our deleted gene is included
+            if deleted_genes.is_superset(fd_gene) {
+                opt_del_id = Some(allele.clone());
+
+                // this is a generic result though, do not exit early because we might find a more specific one
+            } else {
+                // this does not overlap the generic deletion, so no change
+            }
+        } else if deleted_genes.eq(fd_gene) {
+            // the two sets exactly match AND this is non-generic, return this result
+            opt_del_id = Some(allele.clone());
+            break;
+        } else {
+            // the definition does not match the identified value
+        }
+    }
+
+    Ok(opt_del_id)
+}
+
+/// Will see if the given structural variant region matches a described partial deletion.
+/// These are compared based on exon coordinates.
+/// # Arguments
+/// * `gene_collection` - the set of known gene definitions
+/// * `structural_variants` - all defined structural variants to compare against
+/// * `start` - start coordinates of the SV, 0-based inclusive
+/// * `end` - end coordinates of the SV, 0-base exclusive
+fn is_partial_deletion(gene_collection: &GeneCollection, structural_variants: &PgxStructuralVariants, start: u64, end: u64) -> Result<Option<String>, SimpleError> {
+    // get the full set of deletable genes
+    let all_deletable_genes: BTreeSet<String> = structural_variants.partial_gene_deletions().values()
+        .flat_map(|pd| pd.exons_deleted().keys())
+        .cloned()
+        .collect();
+
+    // make sure all the genes have a definition
+    for gene in all_deletable_genes.iter() {
+        if !gene_collection.gene_dict().contains_key(gene) {
+            bail!("Gene collection does not contain a definition for {gene}");
+        }
+    }
+
+    // now get the set of deleted exons
+    let deleted_exons: BTreeMap<String, std::ops::Range<usize>> = all_deletable_genes.iter()
+        .filter_map(|g| {
+            // unwrap was checked for above
+            let gene_def = gene_collection.gene_dict().get(g).unwrap();
+            let mut first_exon_deleted = None;
+            let mut last_exon_deleted = None;
+            for (exon_id, exon_coordinates) in gene_def.exons().iter().enumerate() {
+                let exon_start = exon_coordinates.start();
+                let exon_end = exon_coordinates.end();
+                if exon_start >= start && exon_end <= end {
+                    // the exon is fully contained in the deletion
+                    if first_exon_deleted.is_none() {
+                        first_exon_deleted = Some(exon_id);
+                    }
+                    last_exon_deleted = Some(exon_id);
+                }
+            }
+
+            if let (Some(s_index), Some(e_index)) = (first_exon_deleted, last_exon_deleted) {
+                // we have one or more exons deleted, e_index needs to get +1
+                Some((g.clone(), s_index..(e_index+1)))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    // now figure out if anything matches it
+    let mut opt_del_id: Option<String> = None;
+    for (allele, partial_deletion) in structural_variants.partial_gene_deletions().iter() {
+        let pd_gene = partial_deletion.exons_deleted();
+        if partial_deletion.is_generic() {
+            // this is a generic definition, check if our deletion contains each gene in this list
+            if pd_gene.keys().all(|k| deleted_exons.contains_key(k)) {
+                opt_del_id = Some(allele.clone());
+                // this is a generic result though, do not exit early because we might find a more specific one
+            } else {
+                // this does not overlap the generic deletion, so no change
+            }
+        } else if deleted_exons.eq(pd_gene) {
+            // the two sets exactly match AND this is non-generic, return this result
+            opt_del_id = Some(allele.clone());
+            break;
+        } else {
+            // the definition does not match the identified value
+        }
+    }
+
+    Ok(opt_del_id)
 }
 
 /// This is the workhorse function for computing the diplotype.
@@ -587,7 +1036,9 @@ fn load_vcf_variants(vcf_fn: &Path, variant_hash: &HashMap<NormalizedVariant, Va
 /// * `variant_calls` - the set of variants that were identified as well as their genotype
 /// # Errors
 /// * None so far
-fn solve_diplotype(normalized_haplotypes: &[NormalizedPgxHaplotype], variant_calls: &HashMap<NormalizedVariant, NormalizedGenotype>) -> Result<Vec<Diplotype>, Box<dyn std::error::Error>> {
+fn solve_diplotype(
+    normalized_haplotypes: &[NormalizedPgxHaplotype], variant_calls: &BTreeMap<NormalizedVariant, NormalizedGenotype>
+) -> Result<Vec<Diplotype>, Box<dyn std::error::Error>> {
     // build up our base homozygous haplotype and also order the het variants at the same time
     let mut base_haplotype: Vec<NormalizedVariant> = vec![];
     let mut het_variants: Vec<NormalizedVariant> = vec![];
@@ -615,11 +1066,16 @@ fn solve_diplotype(normalized_haplotypes: &[NormalizedPgxHaplotype], variant_cal
     // now the magic
     let diplotype: Vec<Diplotype> = if het_variants.is_empty() {
         // there are no heterozygous variants, so we are returning a homozygous allele
-        let mut matched: Option<String> = None;
-        for haplotype in normalized_haplotypes.iter() {
-            if haplotype.matches(&base_haplotype) {
-                assert!(matched.is_none());
-                matched = Some(haplotype.haplotype_name().to_string());
+        // first see if there are SVs that dominate all other labels
+        let mut matched: Option<String> = get_sv_haplotype_label(&base_haplotype);
+
+        if matched.is_none() {
+            // no SV label found, revert to normal matching scheme
+            for haplotype in normalized_haplotypes.iter() {
+                if haplotype.matches(&base_haplotype) {
+                    assert!(matched.is_none());
+                    matched = Some(haplotype.haplotype_name().to_string());
+                }
             }
         }
 
@@ -641,7 +1097,7 @@ fn solve_diplotype(normalized_haplotypes: &[NormalizedPgxHaplotype], variant_cal
             let mut h2: Vec<NormalizedVariant> = base_haplotype.clone();
 
             let mut combo_index: usize = 0;
-            let mut ps_lookup: HashMap<usize, bool> = Default::default();
+            let mut ps_lookup: BTreeMap<usize, bool> = Default::default();
             for hv in het_variants.iter() {
                 // let is_h1: bool = ((combination >> i) & 0x1) != 0;
                 let genotype = variant_calls.get(hv).unwrap();
@@ -695,8 +1151,8 @@ fn solve_diplotype(normalized_haplotypes: &[NormalizedPgxHaplotype], variant_cal
             debug!("\t combination {} = {:?}, {:?}", combination, h1, h2);
             
             // now compare them to see if they both match an allele
-            let mut h1_matched: Option<String> = None;
-            let mut h2_matched: Option<String> = None;
+            let mut h1_matched: Option<String> = get_sv_haplotype_label(&h1);
+            let mut h2_matched: Option<String> = get_sv_haplotype_label(&h2);
             for haplotype in normalized_haplotypes.iter() {
                 if haplotype.matches(&h1) {
                     assert!(h1_matched.is_none());
@@ -728,12 +1184,33 @@ fn solve_diplotype(normalized_haplotypes: &[NormalizedPgxHaplotype], variant_cal
     Ok(diplotype)
 }
 
+/// Given a list of variants that are on a haplotype, this will return a String containing all structural variants.
+/// If none are found, then None is returned.
+/// # Arguments
+/// * `variants` - the set of variants to comb through
+fn get_sv_haplotype_label(variants: &[NormalizedVariant]) -> Option<String> {
+    let sv_labels: Vec<&str> = variants.iter()
+        .filter_map(|v| {
+            v.sv_stats().map(|stats| stats.haplotype_label())
+        })
+        .collect();
+
+    if sv_labels.is_empty() {
+        None
+    } else {
+        Some(sv_labels.iter().join(" + "))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     use std::path::PathBuf;
 
+    use crate::data_types::coordinates::Coordinates;
+    use crate::data_types::gene_definition::GeneDefinition;
+    use crate::data_types::pgx_structural_variants::{FullDeletion, PartialDeletion};
     use crate::util::file_io::load_json;
 
     fn load_test_reference() -> ReferenceGenome {
@@ -761,7 +1238,7 @@ mod tests {
         let v1_meta = VariantMeta { variant_id: 777260, name: "faux".to_string(), dbsnp_id: Some("rs772226819".to_string()) };
         let v2 = NormalizedVariant::new("chr1".to_string(), 201060814, "C", "T", None).unwrap();
         let v2_meta = VariantMeta { variant_id: 777261, name: "faux".to_string(), dbsnp_id: Some("rs1800559".to_string()) };
-        let expected_variants = HashMap::from_iter(vec![
+        let expected_variants = BTreeMap::from_iter(vec![
             (v1.clone(), v1_meta),
             (v2.clone(), v2_meta)
         ].into_iter());
@@ -1157,5 +1634,88 @@ mod tests {
 
         let diplotypes = diplotype.gene_details();
         assert_eq!(diplotypes.len(), 0);
+    }
+
+    #[test]
+    fn test_deletion_search() {
+        // build a test gene collection
+        let chrom = "chrom".to_string();
+        let gene1 = "gene1".to_string();
+        let mut gene_def1 = GeneDefinition::new(
+            gene1.clone(),
+            Coordinates::new(chrom.clone(), 10, 50),
+            true
+        );
+        gene_def1.add_exon(Coordinates::new(chrom.clone(), 10, 20)).unwrap();
+        gene_def1.add_exon(Coordinates::new(chrom.clone(), 30, 50)).unwrap();
+
+        let gene2 = "gene2".to_string();
+        let mut gene_def2 = GeneDefinition::new(
+            gene2.clone(),
+            Coordinates::new(chrom.clone(), 100, 200),
+            true
+        );
+        gene_def2.add_exon(Coordinates::new(chrom.clone(), 100, 120)).unwrap();
+        gene_def2.add_exon(Coordinates::new(chrom.clone(), 130, 140)).unwrap();
+        gene_def2.add_exon(Coordinates::new(chrom.clone(), 150, 200)).unwrap();
+
+        let gene_dict: BTreeMap<String, GeneDefinition> = [
+            (gene1.clone(), gene_def1),
+            (gene2.clone(), gene_def2)
+        ].into_iter().collect();
+        let gene_collection = GeneCollection::new("test_version".to_string(), gene_dict);
+
+        // now build some structural variant definitions - lets build these around gene2
+        let mut structural_variants: PgxStructuralVariants = Default::default();
+        structural_variants.add_full_deletion(
+            "generic_del".to_string(),
+            FullDeletion::new(true, [gene2.clone()].into_iter().collect())
+        ).unwrap();
+        structural_variants.add_full_deletion(
+            "double_full_del".to_string(),
+            FullDeletion::new(false, [gene1.clone(), gene2.clone()].into_iter().collect())
+        ).unwrap();
+
+        // now add some partial deletions
+        structural_variants.add_partial_deletion(
+            "generic_partial".to_string(),
+            PartialDeletion::new(
+                true,
+                [(gene2.clone(), 0..3)].into_iter().collect()
+            )
+        ).unwrap();
+        structural_variants.add_partial_deletion(
+            "specific_partial".to_string(),
+            PartialDeletion::new(
+                false,
+                [(gene2.clone(), 1..3)].into_iter().collect()
+            )
+        ).unwrap();
+        structural_variants.add_partial_deletion(
+            "multigene_partial".to_string(),
+            PartialDeletion::new(
+                false,
+                [
+                    (gene1.clone(), 1..2),
+                    (gene2.clone(), 0..1)
+                ].into_iter().collect()
+            )
+        ).unwrap();
+
+        // now all the tests
+        assert_eq!(None, is_deletion(&gene_collection, &structural_variants, 0, 1).unwrap()); // nowhere near the gene
+        assert_eq!(None, is_deletion(&gene_collection, &structural_variants, 125, 127).unwrap()); // intronic
+        assert_eq!(None, is_deletion(&gene_collection, &structural_variants, 125, 135).unwrap()); // overlaps, but no exons fully deleted
+        assert_eq!(None, is_deletion(&gene_collection, &structural_variants, 5, 55).unwrap()); // first gene is fully deleted, but not the one we care about
+
+        // now check for various forms of full gene deletion
+        assert_eq!("generic_del", is_deletion(&gene_collection, &structural_variants, 100, 200).unwrap().unwrap()); // exact gene
+        assert_eq!("generic_del", is_deletion(&gene_collection, &structural_variants, 30, 200).unwrap().unwrap()); // part of the first gene, but not all of it
+        assert_eq!("double_full_del", is_deletion(&gene_collection, &structural_variants, 5, 200).unwrap().unwrap()); // both genes
+
+        // now check for various forms of partial gene deletion
+        assert_eq!("generic_partial", is_deletion(&gene_collection, &structural_variants, 100, 150).unwrap().unwrap()); // partial without specifics
+        assert_eq!("specific_partial", is_deletion(&gene_collection, &structural_variants, 125, 200).unwrap().unwrap()); // defined single-gene partial
+        assert_eq!("multigene_partial", is_deletion(&gene_collection, &structural_variants, 25, 125).unwrap().unwrap()); // defined multi-gene partial
     }
 }


### PR DESCRIPTION
# v1.3.0
## Changes
- Adds support for externally called structural variants and corresponding PGx haplotypes
  - A new option `--sv-vcf` can be used to provide a structural variant VCF file from pbsv or sawfish
  - Updated the database build to include _CYP2C19_ known whole-gene (\*36) and partial-gene deletions (\*37) based on PharmVar definitions
