### PR TITLE
changes for 1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.3.2
+## Changes
+- Added statistics on HLA diplotype calling to the `hla_debug.json` file
+
+## Fixed
+- Instead of throwing an error when encountered a mapped read with no sequence in the HLA regions, the tool will now ignore the read and report a warning in the log
+
 # v1.3.1
 ## Changes
 - Adds additional structural variants to the default database construction: CYP2B6\*29, CYP4F2\*16, SLCO1B1\*48, and SLCO1B1\*49

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1344,7 +1344,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pbstarphase"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "assert_approx_eq",
  "bio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pbstarphase"
-version = "1.3.1"
+version = "1.3.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/LICENSE-THIRDPARTY.json
+++ b/LICENSE-THIRDPARTY.json
@@ -1306,7 +1306,7 @@
   },
   {
     "name": "pbstarphase",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "authors": null,
     "repository": null,
     "license": null,

--- a/docs/debug_outputs.md
+++ b/docs/debug_outputs.md
@@ -76,6 +76,13 @@ Fields:
         * `md` - The MD string of the mapping
       * `dna_mapping` - The same statistics as `cdna_mapping`, but for the full-length DNA sequence. These may be unavailable if the database entry is missing a DNA sequence.
   * `consensus2` - Statistics for the mapping database sequences against consensus sequence 2. All sub-fields are identical to those of `consensus1`.
+* `dual_passing_stats` - Contains the statistics for determining if a diplotype is reported as homozygous or heterozygous. All sub-keys of this dictionary are gene names, `{gene}`, with the following fields:
+  * `is_passing` - if True, then the diplotype is a passing heterozygous call
+  * `is_dual` - if True, then a dual consensus was identified (it may not be passing); if False, the following values will be empty because only a single consensus was identified
+  * `counts1` - the number of reads assigned to consensus 1
+  * `counts2` - the number of reads assigned to consensus 2
+  * `maf` - Minor allele frequency = `min(counts1, counts2) / (counts1 + counts2)`
+  * `cdf` - Cumulative distribution function value for the provided expected MAF
 
 Example:
 ```
@@ -115,6 +122,17 @@ Example:
       "consensus2": {
         ...
       }
+    },
+    ...
+  },
+  "dual_passing_stats": {
+    "HLA-A": {
+      "is_passing": true,
+      "is_dual": true,
+      "counts1": 27,
+      "counts2": 10,
+      "maf": 0.2702702702702703,
+      "cdf": 0.019406414321609413
     },
     ...
   }

--- a/src/hla/realigner.rs
+++ b/src/hla/realigner.rs
@@ -108,10 +108,16 @@ impl<'a> HlaRealigner<'a> {
         // align the read to our database sequence
         let read_bytes = record.seq().as_bytes();
         let read_len = read_bytes.len();
-        let d_mappings = self.db_aligner.map(
-            &read_bytes,
-            output_cigar, output_md, max_frag_len, extra_flags.as_deref(), None
-        )?;
+        let d_mappings = if read_len == 0 {
+            // this can happen when a record has no sequence attached to it
+            warn!("Mapped read found without any sequence, ignoring: {qname}");
+            vec![]
+        } else {
+            self.db_aligner.map(
+                &read_bytes,
+                output_cigar, output_md, max_frag_len, extra_flags.as_deref(), None
+            )?
+        };
 
         // TODO: can we use the shared select_best_mapping function? trick here is we have some cut-offs encoded
         // find the single best mapping for the read


### PR DESCRIPTION
# 1.3.2
## Changes
- Added statistics on HLA diplotype calling to the `hla_debug.json` file

## Fixed
- Instead of throwing an error when encountered a mapped read with no sequence in the HLA regions, the tool will now ignore the read and report a warning in the log